### PR TITLE
Fix: Resolve Trinket equip rollbacks and attribute stacking bugs

### DIFF
--- a/common/src/main/java/net/jewelry/items/JewelryItems.java
+++ b/common/src/main/java/net/jewelry/items/JewelryItems.java
@@ -561,7 +561,8 @@ public class JewelryItems {
             )
     )).setTier(4);
 
-    private static final Identifier modifierId = Identifier.of(JewelryMod.ID, "equipment_bonus");
+    //this line cause stacking bug
+//    private static final Identifier modifierId = Identifier.of(JewelryMod.ID, "equipment_bonus");
     public static void register(ItemConfig allConfigs) {
         for (var entry : all) {
             ItemConfig.Item itemConfig = allConfigs.items.get(entry.id.toString());
@@ -575,11 +576,20 @@ public class JewelryItems {
                 var id = Identifier.of(modifier.id);
                 var attribute = Registries.ATTRIBUTE.getEntry(id);
                 if (attribute.isPresent()) {
+
+                    // --- FIX STACKING BUG ---
+                    // Create Unique ID.
+                    String safeAttributeName = id.getPath().replace(".", "_");
+                    Identifier dynamicModifierId = Identifier.of(JewelryMod.ID,
+                            entry.id().getPath() + "_" + safeAttributeName + "_bonus");
+
                     attributes.add(attribute.get(),
                             new EntityAttributeModifier(
-                                    modifierId,
+                                    dynamicModifierId,
                                     modifier.value,
                                     modifier.operation), AttributeModifierSlot.ANY);
+                    // --------------------------------------------------------
+
                 } else {
                     System.err.println("Failed to resolve EntityAttribute with id: " + modifier.id);
                 }

--- a/fabric/src/main/java/net/jewelry/fabric/compat/trinkets/JewelryTrinketItem.java
+++ b/fabric/src/main/java/net/jewelry/fabric/compat/trinkets/JewelryTrinketItem.java
@@ -18,14 +18,21 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
 import java.util.List;
+import java.util.Map;
 
 public class JewelryTrinketItem extends TrinketItem implements JewelryItem {
+    // PHỤC HỒI LẠI BIẾN CỦA TÁC GIẢ
     private AttributeModifiersComponent customAttributes = AttributeModifiersComponent.builder().build();
     private final String lore;
 
     public JewelryTrinketItem(Settings settings, String lore) {
         super(settings);
         this.lore = lore;
+    }
+
+    // PHỤC HỒI LẠI HÀM CỦA TÁC GIẢ ĐỂ KHÔNG BỊ LỖI BÊN TRINKETSHELPER
+    public void setConfigurableModifiers(AttributeModifiersComponent component) {
+        this.customAttributes = component;
     }
 
     @Override
@@ -36,21 +43,40 @@ public class JewelryTrinketItem extends TrinketItem implements JewelryItem {
         }
     }
 
+    @Override
     public Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier) {
-        var defaultModifiers = super.getModifiers(stack, slot, entity, slotIdentifier);
-        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> mutableModifiers = ArrayListMultimap.create(defaultModifiers);
-        String itemName = net.minecraft.registry.Registries.ITEM.getId(stack.getItem()).getPath();
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> uniqueModifiers = ArrayListMultimap.create();
 
-        for (var entry : this.customAttributes.modifiers()) {
-            Identifier uniqueModId = Identifier.of(slotIdentifier.getNamespace(),
-                    slotIdentifier.getPath() + "_" + itemName + "_" + entry.modifier().id().getPath());
-            mutableModifiers.put(entry.attribute(),
-                    new EntityAttributeModifier(uniqueModId, entry.modifier().value(), entry.modifier().operation()));
+        try {
+            Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> defaultModifiers = super.getModifiers(stack, slot, entity, slotIdentifier);
+            String itemName = net.minecraft.registry.Registries.ITEM.getId(stack.getItem()).getPath();
+
+            for (Map.Entry<RegistryEntry<EntityAttribute>, EntityAttributeModifier> entry : defaultModifiers.entries()) {
+                EntityAttributeModifier modifier = entry.getValue();
+                String attributeName = entry.getKey().value().getTranslationKey().replace("attribute.name.", "");
+
+                String rawPath = slotIdentifier.getPath() + "_" + itemName + "_base_" + attributeName + "_" + modifier.operation().name();
+                String safePath = rawPath.toLowerCase(java.util.Locale.ROOT).replaceAll("[^a-z0-9/._-]", "_");
+
+                uniqueModifiers.put(entry.getKey(), new EntityAttributeModifier(Identifier.of(slotIdentifier.getNamespace(), safePath), modifier.value(), modifier.operation()));
+            }
+            for (AttributeModifiersComponent.Entry entry : this.customAttributes.modifiers()) {
+                EntityAttributeModifier modifier = entry.modifier();
+                String attributeName = entry.attribute().value().getTranslationKey().replace("attribute.name.", "");
+
+                String rawPath = slotIdentifier.getPath() + "_" + itemName + "_" + attributeName + "_" + modifier.operation().name();
+                String safePath = rawPath.toLowerCase(java.util.Locale.ROOT).replaceAll("[^a-z0-9/._-]", "_");
+
+                Identifier uniqueModId = Identifier.of(slotIdentifier.getNamespace(), safePath);
+
+                uniqueModifiers.put(entry.attribute(),
+                        new EntityAttributeModifier(uniqueModId, modifier.value(), modifier.operation()));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        return mutableModifiers;
-    }
-    public void setConfigurableModifiers(AttributeModifiersComponent component) {
-        this.customAttributes = component;
+
+        return uniqueModifiers;
     }
 
     @Override

--- a/fabric/src/main/java/net/jewelry/fabric/compat/trinkets/JewelryTrinketItem.java
+++ b/fabric/src/main/java/net/jewelry/fabric/compat/trinkets/JewelryTrinketItem.java
@@ -1,5 +1,6 @@
 package net.jewelry.fabric.compat.trinkets;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.TrinketItem;
@@ -36,14 +37,18 @@ public class JewelryTrinketItem extends TrinketItem implements JewelryItem {
     }
 
     public Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier) {
-        var modifiers = super.getModifiers(stack, slot, entity, slotIdentifier);
-        for (var entry : this.customAttributes.modifiers()) {
-            modifiers.put(entry.attribute(),
-                    new EntityAttributeModifier(slotIdentifier, entry.modifier().value(), entry.modifier().operation()));
-        }
-        return modifiers;
-    }
+        var defaultModifiers = super.getModifiers(stack, slot, entity, slotIdentifier);
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> mutableModifiers = ArrayListMultimap.create(defaultModifiers);
+        String itemName = net.minecraft.registry.Registries.ITEM.getId(stack.getItem()).getPath();
 
+        for (var entry : this.customAttributes.modifiers()) {
+            Identifier uniqueModId = Identifier.of(slotIdentifier.getNamespace(),
+                    slotIdentifier.getPath() + "_" + itemName + "_" + entry.modifier().id().getPath());
+            mutableModifiers.put(entry.attribute(),
+                    new EntityAttributeModifier(uniqueModId, entry.modifier().value(), entry.modifier().operation()));
+        }
+        return mutableModifiers;
+    }
     public void setConfigurableModifiers(AttributeModifiersComponent component) {
         this.customAttributes = component;
     }


### PR DESCRIPTION
### Description
This PR addresses several critical bugs related to the Trinkets API integration and attribute stacking in Minecraft 1.21. 

Previously, players would experience item loss or rollbacks when equipping rings/necklaces, and attributes from multiple jewelry pieces would not stack correctly.

### Bug Fixes & Changes

**1. Fixed Trinkets `UnsupportedOperationException` (Item Rollback/Loss)**
- **Issue:** `super.getModifiers(...)` from the Trinkets API returns an `ImmutableMultimap`. Attempting to `.put()` custom modifiers directly into it caused a silent server-side exception, rejecting the equip action and causing item desync/loss.
- **Fix:** Used `ArrayListMultimap.create(defaultModifiers)` to safely create a mutable copy in both `JewelryTrinketItem.java` and `RelicTrinketItem.java`.

**2. Fixed `IllegalArgumentException` during quick item swaps**
- **Issue:** Swapping an item in a single-slot location (like `chest/necklace`) quickly caused a modifier ID collision (`Modifier is already applied`), causing the new item to vanish.
- **Fix:** Appended the item's registry name to the Trinket modifier ID to ensure it is 100% unique (e.g., `trinkets:chest/necklace_diamond_necklace_...`).

**3. Fixed Attribute Stacking Bug in `JewelryItems.java`**
- **Issue:** All jewelry items shared a single static modifier ID (`equipment_bonus`). In 1.21+, this causes attributes of the same type to overwrite each other rather than stack (e.g., wearing two rings that grant Max Health only applied the health once).
- **Fix:** Removed the static ID and replaced it with a dynamically generated ID based on the item's name and the attribute's path (`[item_name]_[attribute_name]_bonus`).

### Testing
- Tested equipping, un-equipping, and quick-swapping items in all Trinket slots (Rings, Necklaces) without rollbacks or item loss.
- Verified that attributes (e.g., Max Health, Attack Damage) stack properly when wearing multiple jewelry pieces granting the same stats.